### PR TITLE
Make MockShell methods public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## next version
 
-### 0.1.0
+### Changed
+
+- Make `MockShell` methods public https://github.com/tuist/shell/pull/1
+
+## 0.1.0
 
 - 🎉 First version of the library

--- a/Sources/ShellTesting/MockShell.swift
+++ b/Sources/ShellTesting/MockShell.swift
@@ -16,7 +16,7 @@ public final class MockShell: Shell {
     /// Stubs the given command to succeed.
     ///
     /// - Parameter argument: Command arguments.
-    func succeed(_ argument: [String]) {
+    public func succeed(_ argument: [String]) {
         stub(argument,
              code: 0)
     }
@@ -27,7 +27,7 @@ public final class MockShell: Shell {
     ///   - arguments: Command arguments.
     ///   - stderr: Stub standard error output.
     ///   - code: Stub exit code.
-    func error(_ arguments: [String], stderr: [String], code: Int32 = 1) {
+    public func error(_ arguments: [String], stderr: [String], code: Int32 = 1) {
         stub(arguments,
              stder: stderr,
              code: code)
@@ -43,7 +43,7 @@ public final class MockShell: Shell {
     ///   - stdout: Stub standard output.
     ///   - stder: Stub standard error output.
     ///   - code: Stub exit code.
-    func stub(_ arguments: [String],
+    public func stub(_ arguments: [String],
               shouldBeTerminatedOnParentExit: Bool = true,
               workingDirectoryPath: Path? = nil,
               env: [String: String]? = nil,


### PR DESCRIPTION
### Short description 📝
We forgot to make the `MockShell` methods public.

### Solution 📦
Add the public access level to those methods.