### PR TITLE
Bump Result to 4.1.0

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
 github "tuist/PathKit" "732bff7354542ac64f6515d8ea4895898084b9e1"
-github "antitypical/Result" ~> 4.0.1
+github "antitypical/Result" ~> 4.1.0

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-github "antitypical/Result" "4.0.1"
+github "antitypical/Result" "4.1.0"
 github "tuist/PathKit" "732bff7354542ac64f6515d8ea4895898084b9e1"

--- a/Package.resolved
+++ b/Package.resolved
@@ -15,8 +15,8 @@
         "repositoryURL": "https://github.com/antitypical/Result.git",
         "state": {
           "branch": null,
-          "revision": "f5a5641043bdca66ec00ea349904505b6471365b",
-          "version": "4.0.1"
+          "revision": "2ca499ba456795616fbc471561ff1d963e6ae160",
+          "version": "4.1.0"
         }
       },
       {

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/kylef/PathKit.git", .upToNextMinor(from: "0.9.2")),
-        .package(url: "https://github.com/antitypical/Result.git", .upToNextMinor(from: "4.0.1")),
+        .package(url: "https://github.com/antitypical/Result.git", .upToNextMinor(from: "4.1.0")),
     ],
     targets: [
         .target(

--- a/Shell.podspec
+++ b/Shell.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.source_files = "Sources/Shell/**/*.{swift}"
 
   s.dependency "PathKit", "0.9.2"
-  s.dependency "Result", "4.0.1"
+  s.dependency "Result", "4.1.0"
 end

--- a/ShellTesting.podspec
+++ b/ShellTesting.podspec
@@ -14,5 +14,5 @@ Pod::Spec.new do |s|
   s.source_files = "Sources/ShellTesting/**/*.{swift}"
 
   s.dependency "Shell", "1.0.2"
-  s.dependency "Result", "4.0.1"
+  s.dependency "Result", "4.1.0"
 end


### PR DESCRIPTION
### Short description 📝
Bump Result's version to the latest one, [4.1.0](https://github.com/antitypical/Result/releases)
