### PR TITLE
Fix race condition with threads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## next version
 
+### Fixed
+
+- Race condition in `ProcessRunner` https://github.com/tuist/shell/pull/8 by @pepibumur.
+
 ### Added
 
 - `Shell.succeeds` method https://github.com/tuist/shell/pull/7 by @pepibumur.

--- a/Sources/ShellTesting/MockShell.swift
+++ b/Sources/ShellTesting/MockShell.swift
@@ -49,6 +49,7 @@ public final class MockShell: Shell {
                      stdout: [String] = [],
                      stder: [String] = [],
                      code: Int32 = 0) {
+        //swiftlint:disable:next force_cast
         (runner as! MockProcessRunner).stub(arguments: arguments,
                                             shouldBeTerminatedOnParentExit: shouldBeTerminatedOnParentExit,
                                             workingDirectoryPath: workingDirectoryPath,


### PR DESCRIPTION
### Short description 📝
There was a bug in the `ProcessRunner` that caused a race condition using threads. As a consequence, the command completed before the standard output and error had been forwarded to through the closures.

cc @frowing

### Solution 📦
- Use the `queue` to serialize the execution of the events in the right order.