### PR TITLE
Filehandler deallocation fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ Please, check out guidelines: https://keepachangelog.com/en/1.0.0/
 
 ## next version
 
+### Fixed
+
+- File handlers not getting deallocated after the task completes https://github.com/tuist/shell/pull/9 by @pepibumur.
+
 ## 1.2.0
 
 ### Fixed

--- a/Project.swift
+++ b/Project.swift
@@ -23,5 +23,5 @@ let project = Project(name: "Shell-Carthage",
                                      .framework(path: "Carthage/Build/Mac/PathKit.framework"),
                                      .framework(path: "Carthage/Build/Mac/Result.framework"),
                                      .target(name: "Shell"),
-                          ]),
-])
+                                 ]),
+                      ])

--- a/Sources/Shell/Environment.swift
+++ b/Sources/Shell/Environment.swift
@@ -32,12 +32,12 @@ class Environment: EnvironmentProtocol {
     ///   - currentWorkingDirectory: Path to the current working directory.
     /// - Returns: List of paths exposed through the PATH environment variable.
     func searchPaths(pathString: String?, currentWorkingDirectory: Path) -> [Path] {
-        return (pathString ?? "").split(separator: ":").map(String.init).compactMap({ pathString in
+        return (pathString ?? "").split(separator: ":").map(String.init).compactMap { pathString in
             if pathString.first == "/" {
                 return Path(pathString)
             }
             return currentWorkingDirectory + pathString
-        })
+        }
     }
 
     /// It looks up an executable in the given paths and current directory.
@@ -77,7 +77,7 @@ class Environment: EnvironmentProtocol {
 
         for path in paths {
             let path = path + name
-            if path.exists && path.isExecutable {
+            if path.exists, path.isExecutable {
                 return path
             }
         }

--- a/Sources/Shell/Shell.swift
+++ b/Sources/Shell/Shell.swift
@@ -83,7 +83,7 @@ open class Shell {
                                          env: env,
                                          onStdout: onStdoutData,
                                          onStderr: onStderrData)
-        return result.flatMapError({ .failure(ShellError(processError: $0)) })
+        return result.flatMapError { .failure(ShellError(processError: $0)) }
     }
 
     /// Runs a given command and notifies about its completion asynchronously.
@@ -125,7 +125,7 @@ open class Shell {
             if let onStderr = onStderr, let string = String(data: data, encoding: .utf8) { onStderr(string) }
         }
         let onRunnerCompletion: (Result<Void, ProcessRunnerError>) -> Void = { result in
-            onCompletion(result.flatMapError({ .failure(ShellError(processError: $0)) }))
+            onCompletion(result.flatMapError { .failure(ShellError(processError: $0)) })
         }
         self.runner.runAsync(arguments: arguments,
                              shouldBeTerminatedOnParentExit: shouldBeTerminatedOnParentExit,

--- a/Sources/ShellTesting/MockProcessRunner.swift
+++ b/Sources/ShellTesting/MockProcessRunner.swift
@@ -47,8 +47,8 @@ final class MockProcessRunner: ProcessRunning {
             return .failure(.shell(reason: .exit, code: 1))
         }
 
-        stub.stdout.forEach({ onStdout($0.data(using: .utf8)!) })
-        stub.stderr.forEach({ onStderr($0.data(using: .utf8)!) })
+        stub.stdout.forEach { onStdout($0.data(using: .utf8)!) }
+        stub.stderr.forEach { onStderr($0.data(using: .utf8)!) }
         if stub.code == 0 {
             return .success(())
         } else {
@@ -73,8 +73,8 @@ final class MockProcessRunner: ProcessRunning {
             return
         }
 
-        stub.stdout.forEach({ onStdout($0.data(using: .utf8)!) })
-        stub.stderr.forEach({ onStderr($0.data(using: .utf8)!) })
+        stub.stdout.forEach { onStdout($0.data(using: .utf8)!) }
+        stub.stderr.forEach { onStderr($0.data(using: .utf8)!) }
         if stub.code == 0 {
             return onCompletion(.success(()))
         } else {

--- a/Sources/ShellTesting/MockShell.swift
+++ b/Sources/ShellTesting/MockShell.swift
@@ -6,7 +6,7 @@ public extension Shell {
     /// Returns a mock instance for testing purposes.
     ///
     /// - Returns: Mock instance of shell.
-    public static func mock() -> MockShell {
+    static func mock() -> MockShell {
         return MockShell(runner: MockProcessRunner())
     }
 }
@@ -49,7 +49,7 @@ public final class MockShell: Shell {
                      stdout: [String] = [],
                      stder: [String] = [],
                      code: Int32 = 0) {
-        //swiftlint:disable:next force_cast
+        // swiftlint:disable:next force_cast
         (runner as! MockProcessRunner).stub(arguments: arguments,
                                             shouldBeTerminatedOnParentExit: shouldBeTerminatedOnParentExit,
                                             workingDirectoryPath: workingDirectoryPath,

--- a/Tests/ShellTests/ShellTests.swift
+++ b/Tests/ShellTests/ShellTests.swift
@@ -36,8 +36,7 @@ final class ShellTests: XCTestCase {
                                shouldBeTerminatedOnParentExit: true,
                                workingDirectoryPath: nil,
                                env: nil,
-                               onStdout: nil,
-                               onStderr: { stderr.append($0) })
+                               onStdout: nil) { stderr.append($0) }
 
         XCTAssertNotNil(got.error)
         let expected = "xcrun: error: unable to find utility \"invalid\", not a developer tool or in PATH\n"


### PR DESCRIPTION
### Short description 📝
If the standard output and error `fileHandleForReading.readabilityHandler` is not set to nil after the task completes, those handlers will remain in memory forever.

### Solution 📦
Set them to nil when the task completes.